### PR TITLE
Refine source file drop zone layout

### DIFF
--- a/Convierto/Views/ContentView.swift
+++ b/Convierto/Views/ContentView.swift
@@ -590,7 +590,8 @@ struct SourcePanel: View {
                 isDragging: $isDragging,
                 showError: $showError,
                 errorMessage: $errorMessage,
-                selectedFormat: selectedFormat
+                selectedFormat: selectedFormat,
+                hasFiles: !files.isEmpty
             ) { urls in
                 if urls.isEmpty {
                     onClearAll()

--- a/Convierto/Views/DropZoneView.swift
+++ b/Convierto/Views/DropZoneView.swift
@@ -12,17 +12,26 @@ struct DropZoneView: View {
     @Binding var showError: Bool
     @Binding var errorMessage: String?
     let selectedFormat: UTType
+    let hasFiles: Bool
     let onFilesSelected: ([URL]) -> Void
-    
+
     private let dropDelegate: FileDropDelegate
-    
-    init(isDragging: Binding<Bool>, showError: Binding<Bool>, errorMessage: Binding<String?>, selectedFormat: UTType, onFilesSelected: @escaping ([URL]) -> Void) {
+
+    init(
+        isDragging: Binding<Bool>,
+        showError: Binding<Bool>,
+        errorMessage: Binding<String?>,
+        selectedFormat: UTType,
+        hasFiles: Bool,
+        onFilesSelected: @escaping ([URL]) -> Void
+    ) {
         self._isDragging = isDragging
         self._showError = showError
         self._errorMessage = errorMessage
         self.selectedFormat = selectedFormat
+        self.hasFiles = hasFiles
         self.onFilesSelected = onFilesSelected
-        
+
         self.dropDelegate = FileDropDelegate(
             isDragging: isDragging,
             supportedTypes: [.fileURL],
@@ -65,54 +74,39 @@ struct DropZoneView: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 24)
-                .fill(Color(NSColor.controlBackgroundColor).opacity(0.4))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 24)
-                        .strokeBorder(
-                            LinearGradient(
-                                colors: showError ? 
-                                    [.red.opacity(0.3), .red.opacity(0.2)] :
-                                    isDragging ? 
-                                        [.accentColor.opacity(0.3), .accentColor.opacity(0.2)] :
-                                        [.secondary.opacity(0.1), .secondary.opacity(0.05)],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            ),
-                            lineWidth: isDragging || showError ? 2 : 1
-                        )
-                )
-            
-            VStack(spacing: 16) {
-                // Drop zone content
-                DropZoneContent(
-                    isDragging: isDragging,
-                    showError: showError,
-                    errorMessage: errorMessage,
-                    onTryAgain: {
-                        withAnimation {
-                            showError = false
-                            errorMessage = nil
-                            isDragging = false
-                        }
-                    },
-                    onStartOver: {
-                        withAnimation {
-                            showError = false
-                            errorMessage = nil
-                            isDragging = false
-                            onFilesSelected([])  // Clear any selected files
-                        }
+                .fill(Color(NSColor.windowBackgroundColor))
+                .shadow(color: Color.black.opacity(0.05), radius: 12, x: 0, y: 6)
+
+            DropZoneContent(
+                isDragging: isDragging,
+                showError: showError,
+                errorMessage: errorMessage,
+                hasFiles: hasFiles,
+                onSelectFiles: selectFiles,
+                onTryAgain: {
+                    withAnimation {
+                        showError = false
+                        errorMessage = nil
+                        isDragging = false
                     }
-                )
-            }
-            .padding(40)
+                },
+                onStartOver: {
+                    withAnimation {
+                        showError = false
+                        errorMessage = nil
+                        isDragging = false
+                        onFilesSelected([])  // Clear any selected files
+                    }
+                }
+            )
+            .padding(32)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .contentShape(Rectangle())
         .onTapGesture(perform: selectFiles)
         .onDrop(of: [.fileURL], delegate: dropDelegate)
     }
-    
+
     private func selectFiles() {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = true
@@ -136,90 +130,43 @@ private struct DropZoneContent: View {
     let isDragging: Bool
     let showError: Bool
     let errorMessage: String?
+    let hasFiles: Bool
+    let onSelectFiles: () -> Void
     let onTryAgain: () -> Void
     let onStartOver: () -> Void
-    
+
     var body: some View {
-        VStack(spacing: 16) {
-            ZStack {
-                Circle()
-                    .fill(showError ? Color.red.opacity(0.1) : Color.accentColor.opacity(0.1))
-                    .frame(width: 64, height: 64)
-                
-                Image(systemName: showError ? "exclamationmark.circle.fill" :
-                        isDragging ? "arrow.down.circle.fill" : "square.and.arrow.up.circle.fill")
-                    .font(.system(size: 32, weight: .medium))
-                    .foregroundStyle(
-                        LinearGradient(
-                            colors: showError ? [.red, .red.opacity(0.8)] :
-                                [.accentColor, .accentColor.opacity(0.8)],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                    )
-                    .symbolEffect(.bounce, value: isDragging)
-            }
-            
-            VStack(spacing: 8) {
-                Text(showError ? (errorMessage ?? "Error") :
-                        isDragging ? "Release to Convert" : "Drop Files Here")
-                    .font(.system(size: 16, weight: .medium))
-                
-                if showError {
-                    Text("Try dropping the file again or choose another")
-                        .font(.system(size: 14))
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 32)
-                } else if !isDragging {
-                    Text("or click to browse")
-                        .font(.system(size: 14))
+        VStack(spacing: 24) {
+            HStack(alignment: .center, spacing: 24) {
+                dragAndDropColumn
+
+                VStack(spacing: 16) {
+                    Button(action: onSelectFiles) {
+                        Text("Convert →")
+                            .font(.system(size: 16, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .disabled(!hasFiles)
+                    .opacity(hasFiles ? 1 : 0.5)
+
+                    Text(hasFiles ? "Ready when you are" : "Add files to get started")
+                        .font(.system(size: 13, weight: .medium))
                         .foregroundColor(.secondary)
                 }
+                .frame(width: 180)
+
+                selectionColumn
             }
-            
-            if showError {
-                HStack(spacing: 12) {
-                    Button(action: onStartOver) {
-                        Text("Start Over")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.secondary.opacity(0.2), lineWidth: 1)
-                    )
-                    
-                    Button(action: onTryAgain) {
-                        Text("Try Again")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.white)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(
-                                LinearGradient(
-                                    colors: [.red, .red.opacity(0.8)],
-                                    startPoint: .top,
-                                    endPoint: .bottom
-                                )
-                            )
-                    )
-                }
-            }
-            
+
             if !isDragging && !showError {
                 HStack(spacing: 4) {
                     Text("Press")
                         .font(.system(size: 11))
                         .foregroundColor(.secondary.opacity(0.7))
-                    
+
                     HStack(spacing: 2) {
                         Text("⌘")
                             .font(.system(size: 11, weight: .medium))
@@ -236,15 +183,120 @@ private struct DropZoneContent: View {
                                     .stroke(Color.secondary.opacity(0.1), lineWidth: 0.5)
                             )
                     )
-                    
+
                     Text("to browse formats")
                         .font(.system(size: 11))
                         .foregroundColor(.secondary.opacity(0.7))
                 }
-                .padding(.top, 8)
                 .opacity(0.8)
                 .transition(.opacity)
             }
         }
+    }
+
+    private var dragAndDropColumn: some View {
+        VStack(spacing: 16) {
+            HStack(spacing: 16) {
+                ZStack {
+                    Circle()
+                        .fill(showError ? Color.red.opacity(0.1) : Color.accentColor.opacity(0.1))
+                        .frame(width: 56, height: 56)
+
+                    Image(systemName: showError ? "exclamationmark.circle.fill" :
+                            isDragging ? "arrow.down.circle.fill" : "square.and.arrow.up.circle.fill")
+                        .font(.system(size: 28, weight: .medium))
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: showError ? [.red, .red.opacity(0.8)] :
+                                    [.accentColor, .accentColor.opacity(0.8)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .symbolEffect(.bounce, value: isDragging)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(showError ? (errorMessage ?? "Error") :
+                            isDragging ? "Release to Convert" : "Drag & drop files here")
+                        .font(.system(size: 16, weight: .semibold))
+
+                    if showError {
+                        Text("Try dropping the file again or choose another")
+                            .font(.system(size: 13))
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else if !isDragging {
+                        Text("We’ll automatically convert supported files for you")
+                            .font(.system(size: 13))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+
+            if showError {
+                HStack(spacing: 12) {
+                    Button(action: onStartOver) {
+                        Text("Start Over")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button(action: onTryAgain) {
+                        Text("Try Again")
+                            .font(.system(size: 13, weight: .medium))
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, minHeight: 180, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(
+                    showError ? Color.red.opacity(0.5) :
+                        (isDragging ? Color.accentColor.opacity(0.6) : Color.secondary.opacity(0.25)),
+                    style: StrokeStyle(lineWidth: showError ? 2 : 1.5, dash: [8, 6])
+                )
+                .background(
+                    RoundedRectangle(cornerRadius: 20)
+                        .fill(Color(NSColor.windowBackgroundColor))
+                )
+        )
+    }
+
+    private var selectionColumn: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Prefer manual selection?")
+                .font(.system(size: 15, weight: .semibold))
+
+            Button(action: onSelectFiles) {
+                Text("Select…")
+                    .font(.system(size: 15, weight: .medium))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Label("Browse your library", systemImage: "folder")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.secondary)
+
+                Label("Supports images, video, audio & PDF", systemImage: "doc.richtext")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(24)
+        .frame(width: 220, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.secondary.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.secondary.opacity(0.12), lineWidth: 1)
+                )
+        )
     }
 }


### PR DESCRIPTION
## Summary
- add a `hasFiles` flag to `DropZoneView` so the UI can react to whether any sources were added
- restructure the drop zone to feature a dedicated drag-and-drop area, a centered "Convert →" call-to-action, and a manual selection panel without changing the existing color palette

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d466adcebc83318ab8a3d74b1a318a